### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -15,7 +15,7 @@ contract DeployScript is Script, Sphinx {
     CoreDeployment core;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 BUYBACK_HOOK = "JBBuybackHook";
+    bytes32 BUYBACK_HOOK = "JBBuybackHookV6";
 
     /// @notice tracks the addresses that are required for the chain we are deploying to.
     address weth;


### PR DESCRIPTION
## Summary
- Updated `BUYBACK_HOOK` salt from `JBBuybackHook` to `JBBuybackHookV6`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)