### PR TITLE
Fix low findings buyback registry (L-26, L-27)

### DIFF
--- a/src/JBBuybackHookRegistry.sol
+++ b/src/JBBuybackHookRegistry.sol
@@ -192,6 +192,9 @@ contract JBBuybackHookRegistry is IJBBuybackHookRegistry, ERC2771Context, JBPerm
         // Disallow the hook.
         isHookAllowed[hook] = false;
 
+        // L-26: Clear default hook if it matches the hook being disallowed.
+        if (defaultHook == hook) defaultHook = IJBRulesetDataHook(address(0));
+
         emit JBBuybackHookRegistry_DisallowHook(hook);
     }
 
@@ -207,11 +210,16 @@ contract JBBuybackHookRegistry is IJBBuybackHookRegistry, ERC2771Context, JBPerm
             permissionId: JBPermissionIds.SET_BUYBACK_POOL
         });
 
+        // L-27: Require a non-zero hook before locking. Either the project has one set, or the default exists.
+        IJBRulesetDataHook hook = _hookOf[projectId];
+        if (hook == IJBRulesetDataHook(address(0))) {
+            hook = defaultHook;
+            if (hook == IJBRulesetDataHook(address(0))) revert JBBuybackHookRegistry_HookNotSet(projectId);
+            _hookOf[projectId] = hook;
+        }
+
         // Set the hook to locked.
         hasLockedHook[projectId] = true;
-
-        // If the hook is not set, lock in the default hook.
-        if (_hookOf[projectId] == IJBRulesetDataHook(address(0))) _hookOf[projectId] = defaultHook;
 
         emit JBBuybackHookRegistry_LockHook(projectId);
     }

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -409,6 +409,61 @@ contract Test_BuybackHookRegistry_Unit is Test {
     }
 
     //*********************************************************************//
+    // --- L-26: disallowHook clears defaultHook ------------------------ //
+    //*********************************************************************//
+
+    function test_disallowHook_clearsDefaultIfMatch() public {
+        // Set hookA as default.
+        vm.prank(owner);
+        registry.setDefaultHook(hookA);
+        assertEq(address(registry.defaultHook()), address(hookA));
+
+        // Disallow hookA — should clear the default.
+        vm.prank(owner);
+        registry.disallowHook(hookA);
+
+        assertEq(address(registry.defaultHook()), address(0), "defaultHook should be cleared when disallowed");
+    }
+
+    function test_disallowHook_doesNotClearDefaultIfNoMatch() public {
+        // Set hookA as default, disallow hookB.
+        vm.prank(owner);
+        registry.setDefaultHook(hookA);
+
+        vm.prank(owner);
+        registry.allowHook(hookB);
+
+        vm.prank(owner);
+        registry.disallowHook(hookB);
+
+        assertEq(address(registry.defaultHook()), address(hookA), "defaultHook should remain when disallowing a different hook");
+    }
+
+    //*********************************************************************//
+    // --- L-27: lockHookFor reverts when no hook set ------------------- //
+    //*********************************************************************//
+
+    function test_lockHookFor_revertsWhenNoHookAndNoDefault() public {
+        // No project hook, no default — should revert.
+        vm.prank(projectOwner);
+        vm.expectRevert(abi.encodeWithSelector(JBBuybackHookRegistry.JBBuybackHookRegistry_HookNotSet.selector, projectId));
+        registry.lockHookFor(projectId);
+    }
+
+    function test_lockHookFor_revertsWhenDefaultWasDisallowed() public {
+        // Set default, then disallow it (clears default via L-26).
+        vm.prank(owner);
+        registry.setDefaultHook(hookA);
+        vm.prank(owner);
+        registry.disallowHook(hookA);
+
+        // No project hook, default is now zero — should revert.
+        vm.prank(projectOwner);
+        vm.expectRevert(abi.encodeWithSelector(JBBuybackHookRegistry.JBBuybackHookRegistry_HookNotSet.selector, projectId));
+        registry.lockHookFor(projectId);
+    }
+
+    //*********************************************************************//
     // --- Helpers ------------------------------------------------------- //
     //*********************************************************************//
 


### PR DESCRIPTION
## Summary
- **L-26**: `disallowHook()` now clears `defaultHook` if the hook being disallowed is the current default. Previously, the default would point to a disallowed hook.
- **L-27**: `lockHookFor()` now reverts with `JBBuybackHookRegistry_HookNotSet` if no project hook is set and no default exists. Previously it would silently lock in `address(0)`.

Port of [nana-swap-terminal-v5#11](https://github.com/Bananapus/nana-swap-terminal-v5/pull/11) to the buyback hook registry, which has the identical pattern.

## Test plan
- [x] `test_disallowHook_clearsDefaultIfMatch` — verifies L-26 fix
- [x] `test_disallowHook_doesNotClearDefaultIfNoMatch` — verifies no false clearing
- [x] `test_lockHookFor_revertsWhenNoHookAndNoDefault` — verifies L-27 fix
- [x] `test_lockHookFor_revertsWhenDefaultWasDisallowed` — verifies L-26 + L-27 combined

All 28 registry tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)