### PR TITLE
chore: v6 QC pass

### DIFF
--- a/src/JBBuybackHook.sol
+++ b/src/JBBuybackHook.sol
@@ -63,6 +63,7 @@ contract JBBuybackHook is JBPermissioned, ERC2771Context, IJBBuybackHook {
     error JBBuybackHook_TerminalTokenIsProjectToken(address terminalToken, address projectToken);
     error JBBuybackHook_Unauthorized(address caller);
     error JBBuybackHook_ZeroProjectToken();
+    error JBBuybackHook_AmountOverflow();
     error JBBuybackHook_ZeroTerminalToken();
 
     //*********************************************************************//
@@ -218,7 +219,7 @@ contract JBBuybackHook is JBPermissioned, ERC2771Context, IJBBuybackHook {
         (JBRuleset memory ruleset,) = controller.currentRulesetOf(context.projectId);
 
         // If the hook should base its weight on a currency other than the terminal's currency, determine the
-        // factor. The weight is always a fixed point mumber with 18 decimals. To ensure this, the ratio should use the
+        // factor. The weight is always a fixed point number with 18 decimals. To ensure this, the ratio should use the
         // same number of decimals as the `amountToSwapWith`.
         uint256 weightRatio = context.amount.currency == ruleset.baseCurrency()
             ? 10 ** context.amount.decimals
@@ -383,6 +384,9 @@ contract JBBuybackHook is JBPermissioned, ERC2771Context, IJBBuybackHook {
         // If the slippage tolerance meets or exceeds the maximum, return an empty quote.
         if (slippageTolerance >= TWAP_SLIPPAGE_DENOMINATOR) return 0;
 
+        // Make sure the amount doesn't overflow uint128 before passing to Uniswap.
+        if (amountIn > type(uint128).max) revert JBBuybackHook_AmountOverflow();
+
         // Get a quote based on this TWAP tick.
         amountOut = OracleLibrary.getQuoteAtTick({
             tick: arithmeticMeanTick,
@@ -497,7 +501,7 @@ contract JBBuybackHook is JBPermissioned, ERC2771Context, IJBBuybackHook {
         (JBRuleset memory ruleset,) = controller.currentRulesetOf(context.projectId);
 
         // If the hook should base its weight on a currency other than the terminal's currency, determine the
-        // factor. The weight is always a fixed point mumber with 18 decimals. To ensure this, the ratio should use
+        // factor. The weight is always a fixed point number with 18 decimals. To ensure this, the ratio should use
         // the same number of decimals as the `leftoverAmountInThisContract`.
         uint256 weightRatio = context.amount.currency == ruleset.baseCurrency()
             ? 10 ** context.amount.decimals
@@ -650,7 +654,7 @@ contract JBBuybackHook is JBPermissioned, ERC2771Context, IJBBuybackHook {
         // Store the pool.
         poolOf[projectId][terminalToken] = newPool;
 
-        // Pack and store the TWAP window and the TWAP slippage tolerance in `twapParamsOf`.
+        // Store the TWAP window and the project token.
         twapWindowOf[projectId] = twapWindow;
         projectTokenOf[projectId] = address(projectToken);
 

--- a/src/JBBuybackHookRegistry.sol
+++ b/src/JBBuybackHookRegistry.sol
@@ -46,8 +46,8 @@ contract JBBuybackHookRegistry is IJBBuybackHookRegistry, ERC2771Context, JBPerm
     /// @custom:param projectId The ID of the project to get the locked hook for.
     mapping(uint256 projectId => bool) public override hasLockedHook;
 
-    /// @notice The address of each project's token.
-    /// @custom:param projectId The ID of the project the token belongs to.
+    /// @notice Whether the given hook is allowed for a project.
+    /// @custom:param hook The hook to check.
     mapping(IJBRulesetDataHook hook => bool) public override isHookAllowed;
 
     //*********************************************************************//
@@ -223,6 +223,7 @@ contract JBBuybackHookRegistry is IJBBuybackHookRegistry, ERC2771Context, JBPerm
 
         emit JBBuybackHookRegistry_LockHook(projectId);
     }
+
     /// @notice Set the default hook.
     /// @dev Only the owner can set the default hook.
     /// @param hook The hook to set as the default.

--- a/src/interfaces/IJBBuybackHook.sol
+++ b/src/interfaces/IJBBuybackHook.sol
@@ -20,22 +20,68 @@ interface IJBBuybackHook is IJBPayHook, IJBRulesetDataHook, IUniswapV3SwapCallba
     event PoolAdded(uint256 indexed projectId, address indexed terminalToken, address pool, address caller);
     event TwapWindowChanged(uint256 indexed projectId, uint256 oldWindow, uint256 newWindow, address caller);
 
+    /// @notice The directory of terminals and controllers.
+    /// @return The directory contract.
     function DIRECTORY() external view returns (IJBDirectory);
+
+    /// @notice The contract that exposes price feeds.
+    /// @return The prices contract.
     function PRICES() external view returns (IJBPrices);
+
+    /// @notice The project registry.
+    /// @return The projects contract.
     function PROJECTS() external view returns (IJBProjects);
+
+    /// @notice The token registry.
+    /// @return The tokens contract.
     function TOKENS() external view returns (IJBTokens);
+
+    /// @notice The maximum TWAP window that a project can set.
+    /// @return The maximum TWAP window in seconds.
     function MAX_TWAP_WINDOW() external view returns (uint256);
+
+    /// @notice The minimum TWAP window that a project can set.
+    /// @return The minimum TWAP window in seconds.
     function MIN_TWAP_WINDOW() external view returns (uint256);
+
+    /// @notice The denominator used when calculating TWAP slippage percent values.
+    /// @return The slippage denominator.
     function TWAP_SLIPPAGE_DENOMINATOR() external view returns (uint256);
+
+    /// @notice The uncertain slippage tolerance allowed when the swap size relative to liquidity is ambiguous.
+    /// @return The uncertain TWAP slippage tolerance.
     function UNCERTAIN_TWAP_SLIPPAGE_TOLERANCE() external view returns (uint256);
 
+    /// @notice The address of the Uniswap v3 factory. Used to calculate pool addresses.
+    /// @return The factory address.
     function UNISWAP_V3_FACTORY() external view returns (address);
+
+    /// @notice The wETH contract.
+    /// @return The WETH9 contract.
     function WETH() external view returns (IWETH9);
 
+    /// @notice The Uniswap pool where a given project's token and terminal token pair are traded.
+    /// @param projectId The ID of the project whose token is traded in the pool.
+    /// @param terminalToken The address of the terminal token that the project accepts for payments.
+    /// @return pool The Uniswap v3 pool.
     function poolOf(uint256 projectId, address terminalToken) external view returns (IUniswapV3Pool pool);
-    function projectTokenOf(uint256 projectId) external view returns (address projectTokenOf);
+
+    /// @notice The address of each project's token.
+    /// @param projectId The ID of the project.
+    /// @return The address of the project's token.
+    function projectTokenOf(uint256 projectId) external view returns (address);
+
+    /// @notice The TWAP window for the given project, the period of time over which the TWAP is computed.
+    /// @param projectId The ID of the project.
+    /// @return window The TWAP window in seconds.
     function twapWindowOf(uint256 projectId) external view returns (uint256 window);
 
+    /// @notice Set the pool to use for a given project and terminal token.
+    /// @param projectId The ID of the project to set the pool for.
+    /// @param fee The fee used in the pool being set.
+    /// @param twapWindow The period of time over which the TWAP is computed.
+    /// @param terminalToken The address of the terminal token that payments to the project are made in.
+    /// @return newPool The pool that was set for the project and terminal token.
     function setPoolFor(
         uint256 projectId,
         uint24 fee,
@@ -44,5 +90,9 @@ interface IJBBuybackHook is IJBPayHook, IJBRulesetDataHook, IUniswapV3SwapCallba
     )
         external
         returns (IUniswapV3Pool newPool);
+
+    /// @notice Change the TWAP window for a project.
+    /// @param projectId The ID of the project to set the TWAP window of.
+    /// @param newWindow The new TWAP window in seconds.
     function setTwapWindowOf(uint256 projectId, uint256 newWindow) external;
 }

--- a/src/interfaces/IJBBuybackHookRegistry.sol
+++ b/src/interfaces/IJBBuybackHookRegistry.sol
@@ -11,16 +11,47 @@ interface IJBBuybackHookRegistry is IJBRulesetDataHook {
     event JBBuybackHookRegistry_SetDefaultHook(IJBRulesetDataHook hook);
     event JBBuybackHookRegistry_SetHook(uint256 indexed projectId, IJBRulesetDataHook hook);
 
+    /// @notice The project registry.
+    /// @return The projects contract.
     function PROJECTS() external view returns (IJBProjects);
 
+    /// @notice The default hook used when a project has not set a specific hook.
+    /// @return The default data hook.
     function defaultHook() external view returns (IJBRulesetDataHook);
+
+    /// @notice Whether the hook for the given project is locked and cannot be changed.
+    /// @param projectId The ID of the project.
+    /// @return Whether the hook is locked.
     function hasLockedHook(uint256 projectId) external view returns (bool);
+
+    /// @notice The hook for the given project, or the default hook if none is set.
+    /// @param projectId The ID of the project.
+    /// @return The data hook for the project.
     function hookOf(uint256 projectId) external view returns (IJBRulesetDataHook);
+
+    /// @notice Whether the given hook is allowed to be set for projects.
+    /// @param hook The hook to check.
+    /// @return Whether the hook is allowed.
     function isHookAllowed(IJBRulesetDataHook hook) external view returns (bool);
 
+    /// @notice Allow a hook to be used by projects.
+    /// @param hook The hook to allow.
     function allowHook(IJBRulesetDataHook hook) external;
+
+    /// @notice Disallow a hook from being used by projects.
+    /// @param hook The hook to disallow.
     function disallowHook(IJBRulesetDataHook hook) external;
+
+    /// @notice Lock the hook for a project, preventing it from being changed.
+    /// @param projectId The ID of the project to lock the hook for.
     function lockHookFor(uint256 projectId) external;
+
+    /// @notice Set the default hook used when a project has not set a specific hook.
+    /// @param hook The hook to set as the default.
     function setDefaultHook(IJBRulesetDataHook hook) external;
+
+    /// @notice Set the hook for a specific project.
+    /// @param projectId The ID of the project to set the hook for.
+    /// @param hook The hook to set.
     function setHookFor(uint256 projectId, IJBRulesetDataHook hook) external;
 }

--- a/test/Unit.t.sol
+++ b/test/Unit.t.sol
@@ -2089,6 +2089,85 @@ contract Test_BuybackHook_Unit is TestBaseWorkflow, JBTest {
 
         assertFalse(ERC165Checker.supportsInterface(address(hook), random));
     }
+
+    /// @notice Test that `_getQuote` reverts with `JBBuybackHook_AmountOverflow` when `amountIn > type(uint128).max`.
+    function test_getQuote_revertsOnUint128Overflow() public {
+        // Mock the pool being unlocked.
+        vm.mockCall(address(pool), abi.encodeCall(pool.slot0, ()), abi.encode(0, 0, 0, 1, 0, 0, true));
+
+        // Return an oldest observation older than the TWAP window so that consult is called.
+        mockExpect(
+            address(pool),
+            abi.encodeCall(pool.observations, (0)),
+            abi.encode(block.timestamp - twapWindow - 1, 0, 0, true)
+        );
+
+        // Mock the pool's fee.
+        vm.mockCall(address(pool), abi.encodeCall(pool.fee, ()), abi.encode(uint24(3000)));
+
+        // Set up the TWAP observe mock.
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = twapWindow;
+        secondsAgos[1] = 0;
+
+        int56[] memory tickCumulatives = new int56[](2);
+        tickCumulatives[0] = 100;
+        tickCumulatives[1] = 100 + int56(int32(twapWindow)) * 900; // mean tick = 900
+
+        uint160[] memory secondsPerLiquidity = new uint160[](2);
+        secondsPerLiquidity[0] = 0;
+        secondsPerLiquidity[1] = 1;
+
+        vm.mockCall(
+            address(pool),
+            abi.encodeCall(pool.observe, (secondsAgos)),
+            abi.encode(tickCumulatives, secondsPerLiquidity)
+        );
+
+        // Call with amountIn = type(uint128).max + 1 — should revert.
+        vm.expectRevert(JBBuybackHook.JBBuybackHook_AmountOverflow.selector);
+        hook.ForTest_getQuote(projectId, address(projectToken), uint256(type(uint128).max) + 1, address(weth));
+    }
+
+    /// @notice Test that `_getQuote` does NOT revert when `amountIn == type(uint128).max` (boundary).
+    function test_getQuote_succeedsAtUint128Max() public {
+        // Mock the pool being unlocked.
+        vm.mockCall(address(pool), abi.encodeCall(pool.slot0, ()), abi.encode(0, 0, 0, 1, 0, 0, true));
+
+        // Return an oldest observation older than the TWAP window.
+        mockExpect(
+            address(pool),
+            abi.encodeCall(pool.observations, (0)),
+            abi.encode(block.timestamp - twapWindow - 1, 0, 0, true)
+        );
+
+        // Mock the pool's fee.
+        vm.mockCall(address(pool), abi.encodeCall(pool.fee, ()), abi.encode(uint24(3000)));
+
+        // Set up the TWAP observe mock.
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = twapWindow;
+        secondsAgos[1] = 0;
+
+        int56[] memory tickCumulatives = new int56[](2);
+        tickCumulatives[0] = 100;
+        tickCumulatives[1] = 100 + int56(int32(twapWindow)) * 900;
+
+        uint160[] memory secondsPerLiquidity = new uint160[](2);
+        secondsPerLiquidity[0] = 0;
+        secondsPerLiquidity[1] = 1;
+
+        vm.mockCall(
+            address(pool),
+            abi.encodeCall(pool.observe, (secondsAgos)),
+            abi.encode(tickCumulatives, secondsPerLiquidity)
+        );
+
+        // Call with amountIn = type(uint128).max — should NOT revert.
+        uint256 amountOut = hook.ForTest_getQuote(projectId, address(projectToken), type(uint128).max, address(weth));
+        // Should return a non-zero quote (the pool has liquidity and a valid TWAP).
+        assertGt(amountOut, 0, "Expected non-zero quote at uint128 max boundary");
+    }
 }
 
 /// @notice A mock version of `JBBuybackHook` which exposes internal functions for testing purposes.


### PR DESCRIPTION
## Summary
- Fix "mumber" typo to "number" (2 places in `JBBuybackHook.sol`)
- Fix stale comment referencing `twapParamsOf` storage that no longer exists
- Fix copy-paste NatSpec on `isHookAllowed` mapping ("The address of each project's token" -> accurate description)
- Add uint128 overflow check before casting `amountIn` in `_getQuote` (new `JBBuybackHook_AmountOverflow` error)
- Fix missing blank line between `lockHookFor` and `setDefaultHook` in registry
- Add full NatSpec (`@notice`, `@param`, `@return`) to all functions in `IJBBuybackHook` and `IJBBuybackHookRegistry`

## Test plan
- [ ] Verify compilation succeeds
- [ ] Verify existing tests still pass
- [ ] Review NatSpec accuracy against implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)